### PR TITLE
fix #23: loadImages throws error instead of attempting to call exit()

### DIFF
--- a/lib/input_stream.js
+++ b/lib/input_stream.js
@@ -26,8 +26,8 @@ InputStream.createImageStream = function() {
         loaded = false;
         GetPixels(baseUrl, _config.mime, function(err, pixels) {
             if (err) {
-                console.log(err);
-                exit(1);
+                console.error('**** quagga loadImages error:', err);
+                throw new Error('error decoding pixels in loadImages');
             }
             loaded = true;
             console.log(pixels.shape);


### PR DESCRIPTION
- there is no exit() function in node or browser, it's inappropriate to
  call process.exit
- future update might be necessary to do some cleanup after error is
  thrown?