### PR TITLE
fix #92: double timeout for tests

### DIFF
--- a/test/integration/integration.spec.js
+++ b/test/integration/integration.spec.js
@@ -25,7 +25,7 @@ describe('decodeSingle', function () {
         };
     }
 
-    this.timeout(10000);
+    this.timeout(20000);
 
     function _runTestSet(testSet, config, formatOverride) {
         var readers = config.decoder.readers.slice(),
@@ -362,7 +362,7 @@ describe('decodeSingle', function () {
     });
 
     describe('2of5', function() {
-        var config = config = {
+        var config = {
                 inputStream: {
                     size: 800,
                     singleChannel: false,
@@ -399,7 +399,7 @@ describe('decodeSingle', function () {
     });
 
     describe('code_93', function() {
-        var config = config = {
+        var config = {
                 inputStream: {
                     size: 800,
                     singleChannel: false,


### PR DESCRIPTION

- since each test had to run through all 12 of
  the sample files for each one, it would fail
  on my throttled laptop
- doubling the timeout allows them all to
  complete even at 750MHz.