### PR TITLE
Expose library on the global namespace under Quagga

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -30,7 +30,8 @@ module.exports = {
         path: __dirname + '/../dist',
         publicPath: '/',
         libraryTarget: 'umd',
-        library: 'quagga',
+        libraryExport: 'default',
+        library: 'Quagga',
         filename: 'quagga.js',
     },
     devServer: {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "Thomas <tricki@users.noreply.github.com>",
     "jclarkin <j.r.clarkin@gmail.com>",
     "kieat <kieat@users.noreply.github.com>",
-    "Esteban Morales <red_bandit_11@hotmail.com>"
+    "Esteban Morales <red_bandit_11@hotmail.com>", 
+    "Ward Lootens <wardlootens@gmail.com>"
   ],
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Since d2387aa (I guess), the `dist/quagga.js` no longer exposes he library on the global namespace under `Quagga`.

This is fixed by this pull request.

See https://webpack.js.org/configuration/output/#outputlibrarytarget