### PR TITLE
Don't fail when stop() is called before init()

### DIFF
--- a/src/quagga.js
+++ b/src/quagga.js
@@ -513,7 +513,7 @@ export default {
     stop: function() {
         _stopped = true;
         adjustWorkerPool(0);
-        if (_config.inputStream.type === 'LiveStream') {
+        if (_config.inputStream && _config.inputStream.type === 'LiveStream') {
             CameraAccess.release();
             _inputStream.clearEventHandlers();
         }


### PR DESCRIPTION
When `Quagga.stop()` is called before `Quagga.init()` was called, this causes a TypeError, because `_config.inputStream` is `undefined`.

Not the most important fix, but does not harm to fix either.