### PR TITLE
Allow CSS selector for inputstream.target

### DIFF
--- a/type-definitions/quagga.d.ts
+++ b/type-definitions/quagga.d.ts
@@ -390,7 +390,7 @@ export interface QuaggaJSConfigObject {
          */
         type?: string;
 
-        target?: HTMLElement,
+        target?: HTMLElement | string,
 
         constraints?: MediaTrackConstraints;
 


### PR DESCRIPTION
According to doc:
>> (...) target can be a string (CSS selector matching one of your DOM node) or a DOM node

And this actually works correctly with both.

However, the type definitions does not allow for `string` (CSS selector), causing compile errors when using Quagga from another TypeScript module,.