### PR TITLE
Allow to remove all handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,12 @@ is the same as in `onDetected` and contains the result `data` object.
 ### Quagga.offProcessed(handler)
 
 In case the `onProcessed` event is no longer relevant, `offProcessed` removes
-the given `handler` from the event-queue.
+the given `handler` from the event-queue. When no handler is passed, all handlers are removed.
 
 ### Quagga.offDetected(handler)
 
 In case the `onDetected` event is no longer relevant, `offDetected` removes
-the given `handler` from the event-queue.
+the given `handler` from the event-queue. When no handler is passed, all handlers are removed.
 
 ## <a name="resultobject">The result object</a>
 

--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -90,7 +90,7 @@ export default (function() {
                 once: true,
             });
         },
-        unsubscribe: function(eventName: EventName, callback: Function | Subscription) {
+        unsubscribe: function(eventName: EventName, callback?: Function | Subscription) {
             var event;
 
             if (eventName) {

--- a/type-definitions/quagga.d.ts
+++ b/type-definitions/quagga.d.ts
@@ -120,7 +120,7 @@ export interface QuaggaJSStatic {
     /**
      * Removes a callback that was previously registered with @see onProcessed
      */
-    offProcessed(callback: QuaggaJSResultCallbackFunction): void;
+    offProcessed(callback?: QuaggaJSResultCallbackFunction): void;
 
     /**
      * Registers a callback(data) function which is triggered whenever a
@@ -133,7 +133,7 @@ export interface QuaggaJSStatic {
     /**
      * Removes a callback that was previously registered with @see onDetected
      */
-    offDetected(callback: QuaggaJSResultCallbackFunction): void;
+    offDetected(callback?: QuaggaJSResultCallbackFunction): void;
 
     ResultCollector: QuaggaJSResultCollector;
     registerResultCollector(resultCollector: QuaggaJSResultCollector): void;


### PR DESCRIPTION
The `QuaggaJSStatic` enforces that a callback is passes to the `offProcessed`/`offDetected` methods.
However, the implementation handles the case with no passed handler as expected, by removing all registered handlers.

So we might as well change the type definition to allow for this.