### PR TITLE
fix #256 update mediaDevice/cameraAccess error messages for iOS

### DIFF
--- a/.ncurc.json
+++ b/.ncurc.json
@@ -1,0 +1,7 @@
+{
+    "upgrade": true,
+    "reject": [
+        "mocha",
+        "@types/mocha"
+    ]
+}

--- a/src/common/mediaDevices.ts
+++ b/src/common/mediaDevices.ts
@@ -1,8 +1,19 @@
+const ERROR_DESC = 'This may mean that the user has declined camera access, or the browser does not support media APIs. If you are running in iOS, you must use Safari.';
+
+interface Error {
+    name: string;
+    message: string;
+    stack?: string;
+    code?: number;
+}
+
 export function enumerateDevices(): Promise<Array<MediaDeviceInfo>> {
     try {
         return navigator.mediaDevices.enumerateDevices();
     } catch (err) {
-        return Promise.reject(new Error('enumerateDevices is not defined'));
+        const error: Error = new Error(`enumerateDevices is not defined. ${ERROR_DESC}`);
+        error.code = -1;
+        return Promise.reject(error);
     }
 }
 
@@ -10,6 +21,8 @@ export function getUserMedia(constraints: MediaStreamConstraints): Promise<Media
     try {
         return navigator.mediaDevices.getUserMedia(constraints);
     } catch (err) {
-        return Promise.reject(new Error('getUserMedia is not defined'));
+        const error: Error = new Error(`getUserMedia is not defined. ${ERROR_DESC}`);
+        error.code = -1;
+        return Promise.reject(error);
     }
 }

--- a/src/common/test/node/mediaDevices.spec.ts
+++ b/src/common/test/node/mediaDevices.spec.ts
@@ -9,7 +9,8 @@ describe('mediaDevices (node)', () => {
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions,no-unused-expressions
             expect(x).to.not.exist;
         } catch (err) {
-            expect(err.message).to.equal('enumerateDevices is not defined');
+            // expect(err.message).to.equal('enumerateDevices is not defined');
+            expect(err.code).to.equal(-1);
         }
     });
     it('getUserMedia rejects', async () => {
@@ -18,7 +19,8 @@ describe('mediaDevices (node)', () => {
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions,no-unused-expressions
             expect(x).to.not.exist;
         } catch (err) {
-            expect(err.message).to.equal('getUserMedia is not defined');
+            // expect(err.message).to.equal('getUserMedia is not defined');
+            expect(err.code).to.equal(-1);
         }
     });
 });

--- a/src/input/camera_access.ts
+++ b/src/input/camera_access.ts
@@ -76,6 +76,7 @@ export function pickConstraints(videoConstraints: MediaTrackConstraintsWithDepre
 }
 
 async function enumerateVideoDevices(): Promise<Array<MediaDeviceInfo>> {
+
     const devices = await enumerateDevices();
     return devices.filter((device: MediaDeviceInfo) => device.kind === 'videoinput');
 }

--- a/src/input/test/node/camera_access.spec.ts
+++ b/src/input/test/node/camera_access.spec.ts
@@ -12,7 +12,8 @@ describe('CameraAccess (node)', () => {
                 // eslint-disable-next-line @typescript-eslint/no-unused-expressions,no-unused-expressions
                 expect(x).to.not.exist;
             } catch (err) {
-                expect(err.message).to.equal('enumerateDevices is not defined');
+                // expect(err.message).to.equal('enumerateDevices is not defined');
+                expect(err.code).to.equal(-1);
             }
         });
     });
@@ -25,7 +26,8 @@ describe('CameraAccess (node)', () => {
                 // eslint-disable-next-line @typescript-eslint/no-unused-expressions,no-unused-expressions
                 expect(x).to.not.exist;
             } catch (err) {
-                expect(err.message).to.equal('getUserMedia is not defined');
+                // expect(err.message).to.equal('getUserMedia is not defined');
+                expect(err.code).to.equal(-1);
             }
         });
     });


### PR DESCRIPTION
- clarify that iOS is not expected to work when using WebView (Chrome,
  Edge, anything but Safari)
- add an error code to Error throws, something all good errors should have
- will file new issue to add codes to all other instances of Error