### PR TITLE
Use per-method files when importing lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
     "Taylor Southwick <twsouthwick@outlook.com>",
     "Youri Westerman <tetracon@gmail.com>",
     "Stefano Calì <stefanocali@gmail.com>",
-    "Tony Brix <tony@brix.ninja>"
+    "Tony Brix <tony@brix.ninja>",
+    "Alex Howes <alex@alexhowes.co.uk>"
   ],
   "license": "MIT",
   "engines": {

--- a/src/input/camera_access.ts
+++ b/src/input/camera_access.ts
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import pick from 'lodash/pick';
 import { getUserMedia, enumerateDevices } from '../common/mediaDevices';
 import { MediaTrackConstraintsWithDeprecated } from '../../type-definitions/quagga.d';
 

--- a/src/locator/test/barcode_locator.spec.ts
+++ b/src/locator/test/barcode_locator.spec.ts
@@ -4,7 +4,7 @@ if (typeof (globalThis as any).ENV === 'undefined') {
 
 import BarcodeLocator from '../barcode_locator';
 import QuaggaConfig from '../../config/config';
-import {merge} from 'lodash';
+import merge from 'lodash/merge';
 import sinon, {SinonSpy} from 'sinon';
 import { expect } from 'chai';
 import { QuaggaJSConfigObject } from '../../../type-definitions/quagga';

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -7,7 +7,7 @@ import CameraAccess from './input/camera_access';
 import ImageDebug from './common/image_debug';
 import ResultCollector from './analytics/result_collector';
 import Config from './config/config';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 
 import Quagga from './quagga/quagga';
 

--- a/src/reader/ean_reader.ts
+++ b/src/reader/ean_reader.ts
@@ -1,5 +1,5 @@
 import BarcodeReader, { BarcodeReaderConfig, BarcodeInfo, BarcodePosition, Barcode } from './barcode_reader';
-import { merge } from 'lodash';
+import merge from 'lodash/merge';
 
 // const CODE_L_START = 0;
 const CODE_G_START = 10;

--- a/src/reader/i2of5_reader.ts
+++ b/src/reader/i2of5_reader.ts
@@ -1,7 +1,7 @@
 // TODO: i2of5_reader and 2of5_reader share very similar code, make use of that
 
 import BarcodeReader, { BarcodeReaderConfig, BarcodeInfo, BarcodePosition, Barcode } from './barcode_reader';
-import {merge} from 'lodash';
+import merge from 'lodash/merge';
 
 const N = 1;
 const W = 3;


### PR DESCRIPTION
This decreases file size:

**Before**
Non-min: 3.8mb
Min: 285kb

**After**
Non-min 2.6mb
Min: 231kb

Testing using the dist files will be needed as I don't have a project setup on this computer for it.

Here's lodash's documentation on this:
https://lodash.com/per-method-packages