### PR TITLE
urgent: prevent input_stream_node being included in bundle for browser

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = {
         new webpack.DefinePlugin({
             ENV: require(path.join(__dirname, './env/', process.env.BUILD_ENV)),
         }),
+        new webpack.NormalModuleReplacementPlugin(/input_stream_node/, './input_stream/input_stream_browser'),
     ],
     optimization: {
         minimize: false,

--- a/configs/webpack.node.config.js
+++ b/configs/webpack.node.config.js
@@ -16,6 +16,7 @@ module.exports.plugins = [
     new webpack.DefinePlugin({
         ENV: require(path.join(__dirname, './env/', process.env.BUILD_ENV)),
     }),
+    new webpack.NormalModuleReplacementPlugin(/input_stream_browser/, './input_stream/input_stream_node'),
 ];
 module.exports.output.path = __dirname + '/../lib';
 module.exports.output.filename = 'quagga.js';


### PR DESCRIPTION
- should prevent servers using secure CSP settings from serving up errors
  and blank screens
- see issue #269 for future related action