### PR TITLE
Readme: Updated script tags with CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,23 +128,23 @@ to go. The script exposes the library on the global namespace under `Quagga`.
 <script src="quagga.js"></script>
 ```
 
-You can get the `quagga.js` file in two ways:
+You can get the `quagga.js` file in the following ways:
 
-1. By installing the npm module and copying the `quagga.js` file from the `dist` folder.
-
-<p align="center">(OR)</p>
-
-2. You can also build the library yourself and copy `quagga.js` file from the `dist` folder(refer to the [building](https://github.com/ericblade/quagga2#building) section for more details) 
+By [installing the npm module](https://github.com/SudhamJayanthi/quagga2#npm) and copying the `quagga.js` file from the `dist` folder.
 
 <p align="center">(OR)</p>
 
-3. You can include the following script tags with  CDN links:
+You can also build the library yourself and copy `quagga.js` file from the `dist` folder(refer to the [building](https://github.com/ericblade/quagga2#building) section for more details) 
 
-   a) `quagga.js`
+<p align="center">(OR)</p>
+
+You can include the following script tags with  CDN links:
+
+a) `quagga.js`
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2/dist/quagga.js"></script>
 ```
-   b) `quagga.min.js` (minified version)
+b) `quagga.min.js` (minified version)
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2/dist/quagga.min.js"></script>
 ```

--- a/README.md
+++ b/README.md
@@ -125,6 +125,24 @@ You can simply include `dist/quagga.min.js` in your project and you are ready
 to go. The script exposes the library on the global namespace under `Quagga`.
 
 
+<p align="center">(OR)</p>
+
+
+You can include the following CDN links in your script tags:
+
+
+a) `Quagga.js`
+```html
+<script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2@1.2.6/dist/quagga.js"></script>
+```
+
+b) `Quagga.min.js`
+```html
+<script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2@1.2.6/dist/quagga.min.js"></script>
+```
+
+
+
 ## <a name="gettingstarted">Getting Started</a>
 
 For starters, have a look at the [examples][github_examples] to get an idea

--- a/README.md
+++ b/README.md
@@ -119,29 +119,40 @@ Currently, the full functionality is only available through the browser. When
 using QuaggaJS within __node__, only file-based decoding is available. See the
 example for [node_examples](#node-example).
 
-### Using with script tag
+### Using with script tag 
 
-You can simply include `dist/quagga.min.js` in your project and you are ready
+You can simply include `quagga.js` in your project and you are ready
 to go. The script exposes the library on the global namespace under `Quagga`.
 
+```html
+<script src="quagga.js"></script>
+```
+
+You can get the `quagga.js` file in two ways:
+
+1. By installing the npm module and copying the `quagga.js` file from the `dist` folder.
 
 <p align="center">(OR)</p>
 
+2. You can also build the library yourself and copy `quagga.js` file from the `dist` folder(refer to the [building](https://github.com/ericblade/quagga2#building) section for more details) 
 
-You can include the following CDN links in your script tags:
+<p align="center">(OR)</p>
 
+3. You can include the following script tags with  CDN links:
 
-a) `Quagga.js`
+   a) `quagga.js`
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2@1.2.6/dist/quagga.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2/dist/quagga.js"></script>
 ```
-
-b) `Quagga.min.js`
+   b) `quagga.min.js` (minified version)
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2@1.2.6/dist/quagga.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@ericblade/quagga2/dist/quagga.min.js"></script>
 ```
-
-
+*Note: You can include a specific version of the library by including the version as shown below.*
+```html
+<!-- Link for Version 1.2.6 -->
+<script src="https://cdn.jsdelivr.net/npm/@ericblade@version/quagga2@1.2.6/dist/quagga.js"></script>
+```
 
 ## <a name="gettingstarted">Getting Started</a>
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "Youri Westerman <tetracon@gmail.com>",
     "Stefano Calì <stefanocali@gmail.com>",
     "Tony Brix <tony@brix.ninja>",
-    "Alex Howes <alex@alexhowes.co.uk>"
+    "Alex Howes <alex@alexhowes.co.uk>",
+    "Sudham Jayanthi <workwithsudham@gmail.com>"
   ],
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Generated CDN links with [JS Deliver](https://www.jsdelivr.com/) and added in the Readme.md installation section!