### PR TITLE
testing bug fix for android 11 freezing and other chromes not releasing camera

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ericblade/quagga2",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "description": "An advanced barcode-scanner written in JavaScript",
   "main": "lib/quagga.js",
   "types": "type-definitions/quagga.d.ts",

--- a/src/input/test/browser/camera_access.spec.ts
+++ b/src/input/test/browser/camera_access.spec.ts
@@ -112,7 +112,7 @@ describe('CameraAccess (browser)', () => {
         it('works', async () => {
             const video = document.createElement('video');
             await Quagga.CameraAccess.request(video, {});
-            Quagga.CameraAccess.release();
+            await Quagga.CameraAccess.release();
             expect(((video?.srcObject) as any)?.active).to.equal(false);
         });
     });

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -1,3 +1,4 @@
+import merge from 'lodash/merge';
 import TypeDefs from './common/typedefs'; // eslint-disable-line no-unused-vars
 import ImageWrapper from './common/image_wrapper';
 import BarcodeDecoder from './decoder/barcode_decoder';
@@ -7,7 +8,6 @@ import CameraAccess from './input/camera_access';
 import ImageDebug from './common/image_debug';
 import ResultCollector from './analytics/result_collector';
 import Config from './config/config';
-import merge from 'lodash/merge';
 
 import Quagga from './quagga/quagga';
 
@@ -39,10 +39,10 @@ const QuaggaJSStaticInterface = {
         return promise;
     },
     start: function () {
-        instance.start();
+        return instance.start();
     },
     stop: function () {
-        instance.stop();
+        return instance.stop();
     },
     pause: function () {
         _context.stopped = true;

--- a/src/quagga/quagga.ts
+++ b/src/quagga/quagga.ts
@@ -256,11 +256,11 @@ export default class Quagga {
         }
     }
 
-    stop(): void {
+    async stop(): Promise<void> {
         this.context.stopped = true;
         QWorkers.adjustWorkerPool(0);
         if (this.context.config?.inputStream && this.context.config.inputStream.type === 'LiveStream') {
-            CameraAccess.release();
+            await CameraAccess.release();
             this.context.inputStream.clearEventHandlers();
         }
     }

--- a/test/test-import.js
+++ b/test/test-import.js
@@ -15,7 +15,7 @@ describe('testing node import', () => {
         const { CameraAccess: CA } = Q;
         expect(CA).to.be.an('object').with.keys([
             'request', 'release', 'enumerateVideoDevices',
-            'getActiveStreamLabel', 'getActiveTrack',
+            'getActiveStreamLabel', 'getActiveTrack', 'requestedVideoElement',
         ]);
     });
 });

--- a/type-definitions/quagga.d.ts
+++ b/type-definitions/quagga.d.ts
@@ -118,13 +118,13 @@ export interface QuaggaJSStatic {
     init(
         config: QuaggaJSConfigObject,
         callback?: (err: any) => void
-    ): void;
+    ): Promise<void>;
 
     init(
         config: QuaggaJSConfigObject,
         callback: (err: any) => void,
         imageWrapper: ImageWrapper,
-    ): void;
+    ): Promise<void>;
 
     /**
      * When the library is initialized, the start()
@@ -139,7 +139,7 @@ export interface QuaggaJSStatic {
      * Additionally, if a camera-stream was requested upon initialization,
      * this operation also disconnects the camera.
      */
-    stop(): void;
+    stop(): Promise<void>;
 
     /**
      * Pauses processing, but does not release any handlers
@@ -220,9 +220,10 @@ export interface QuaggaJSStatic {
  * Used for accessing information about the active stream track and available video devices.
  */
 export interface QuaggaJSCameraAccess {
-    request(video: HTMLVideoElement, videoConstraints: MediaTrackConstraintsWithDeprecated): Promise<void> | never;
+    requestedVideoElement: HTMLVideoElement | null,
+    request(video: HTMLVideoElement, videoConstraints?: MediaTrackConstraintsWithDeprecated): Promise<void> | never;
 
-    release(): void;
+    release(): Promise<void>;
 
     enumerateVideoDevices(): Promise<MediaDeviceInfo[]> | never;
 


### PR DESCRIPTION
- also update several bits of the typescript spec that have not been
  updated when the relevant code changed
- internal Quagga module stop() returns Promise<void> instead of void,
  and external Quagga module returns same value -- this allows you to
  wait until the stop code has hopefully completely executed before
  continuing on with whatever you do next.  You can also choose to ignore
  the return, just as we always have done.
- internal Quagga module keeps track of the HTMLVideoElement that was
  last requested, and if there is one, it calls pause() on it, before
  calling stop() on the MediaStreamTrack
- The stop() is called on MediaStreamTrack asynchronously, to give the
  browser a chance to actually pause, before disconnecting.
- See https://github.com/ericblade/quagga2/issues/266 and all linked
  issues on it for an incredible amount of detail related to this problem
- I have to commit this before I can fully test it, as I don't have access
  to Android 11 or a Pixel device.  I also need to test it on my production
  server, so this is going straight to a new version, without actual
  testing.  My apologies, but this is one of those bits that are very
  difficult to test outside of real life because of the limitations of
  using cameras and such :|
- QuaggaJSCameraAccess::stop() now also returns Promise<void>.
- Quagga.init() is marked to return Promise<void>
- QuaggaJSCameraAccess::request() is correctly marked as having optional
  videoConstraints now