### PR TITLE
CameraAccess.request should allow for null video element to be passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ericblade/quagga2",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "An advanced barcode-scanner written in JavaScript",
   "main": "lib/quagga.js",
   "types": "type-definitions/quagga.d.ts",

--- a/src/input/camera_access.ts
+++ b/src/input/camera_access.ts
@@ -33,18 +33,21 @@ function waitForVideo(video: HTMLVideoElement): Promise<void> {
  * @param {Object} constraints
  * @param {Object} video
  */
-async function initCamera(video: HTMLVideoElement, constraints: MediaStreamConstraints): Promise<void> {
+async function initCamera(video: HTMLVideoElement | null, constraints: MediaStreamConstraints): Promise<void> {
     const stream = await getUserMedia(constraints);
     streamRef = stream;
-    video.setAttribute('autoplay', 'true');
-    video.setAttribute('muted', 'true');
-    video.setAttribute('playsinline', 'true'); // not listed on MDN...
-    // eslint-disable-next-line no-param-reassign
-    video.srcObject = stream;
-    video.addEventListener('loadedmetadata', () => {
-        video.play();
-    });
-    return waitForVideo(video);
+    if (video) {
+        video.setAttribute('autoplay', 'true');
+        video.setAttribute('muted', 'true');
+        video.setAttribute('playsinline', 'true'); // not listed on MDN...
+        // eslint-disable-next-line no-param-reassign
+        video.srcObject = stream;
+        video.addEventListener('loadedmetadata', () => {
+            video.play();
+        });
+        return waitForVideo(video);
+    }
+    return Promise.resolve();
 }
 
 function deprecatedConstraints(videoConstraints: MediaTrackConstraintsWithDeprecated): MediaTrackConstraints {
@@ -76,7 +79,6 @@ export function pickConstraints(videoConstraints: MediaTrackConstraintsWithDepre
 }
 
 async function enumerateVideoDevices(): Promise<Array<MediaDeviceInfo>> {
-
     const devices = await enumerateDevices();
     return devices.filter((device: MediaDeviceInfo) => device.kind === 'videoinput');
 }
@@ -94,7 +96,7 @@ function getActiveTrack(): MediaStreamTrack | null {
  */
 const QuaggaJSCameraAccess: CameraAccessType = {
     requestedVideoElement: null,
-    async request(video: HTMLVideoElement, videoConstraints?: MediaTrackConstraintsWithDeprecated): Promise<any> {
+    async request(video: HTMLVideoElement | null, videoConstraints?: MediaTrackConstraintsWithDeprecated): Promise<any> {
         QuaggaJSCameraAccess.requestedVideoElement = video;
         const newConstraints = await pickConstraints(videoConstraints);
         return initCamera(video, newConstraints);

--- a/src/input/test/browser/camera_access.spec.ts
+++ b/src/input/test/browser/camera_access.spec.ts
@@ -44,15 +44,17 @@ describe('CameraAccess (browser)', () => {
 
     describe('request', () => {
         it('works', async () => {
-            after(() => Quagga.CameraAccess.release());
             const video = document.createElement('video');
+            after(() => {
+                video.pause();
+                Quagga.CameraAccess.release();
+            });
             await Quagga.CameraAccess.request(video, {});
             expect(video.srcObject).to.not.equal(null);
             // "as any" here to prevent typescript blowing up because it doesn't understand 'id' and
             // 'active' as members of MediaStream | MediaSource | Blob .. why?
             expect(((video?.srcObject) as any)?.id).to.be.a('string');
             expect(((video?.srcObject) as any)?.active).to.equal(true);
-            // TODO: ensure we cleanup our video element after this
         });
 
         it('should allow deprecated constraints to be used', async () => {

--- a/src/input/test/node/camera_access.spec.ts
+++ b/src/input/test/node/camera_access.spec.ts
@@ -21,7 +21,6 @@ describe('CameraAccess (node)', () => {
     describe('request', () => {
         it('rejects', async () => {
             try {
-                // @ts-expect-error
                 const x = await Quagga.CameraAccess.request(null, {});
                 // eslint-disable-next-line @typescript-eslint/no-unused-expressions,no-unused-expressions
                 expect(x).to.not.exist;

--- a/type-definitions/quagga.d.ts
+++ b/type-definitions/quagga.d.ts
@@ -221,7 +221,7 @@ export interface QuaggaJSStatic {
  */
 export interface QuaggaJSCameraAccess {
     requestedVideoElement: HTMLVideoElement | null,
-    request(video: HTMLVideoElement, videoConstraints?: MediaTrackConstraintsWithDeprecated): Promise<void> | never;
+    request(video: HTMLVideoElement | null, videoConstraints?: MediaTrackConstraintsWithDeprecated): Promise<void> | never;
 
     release(): Promise<void>;
 


### PR DESCRIPTION
- this is so there's a way to trigger a camera authorization request on
  mobile Chrome.
- mobile Chrome does *not* ask for permissions when you call
  enumerateDevices() like desktop Chrome does.
- Therefore, if you want to be able to get permission *before* you
  enumerateDevices(), you might need to be able to invisibly turn on/off
  the camera
- You can do await Quagga.CameraAccess.request(null); await Quagga.CameraAccess.release();