### PR TITLE
Export Readers for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "Stefano Calì <stefanocali@gmail.com>",
     "Tony Brix <tony@brix.ninja>",
     "Alex Howes <alex@alexhowes.co.uk>",
-    "Sudham Jayanthi <workwithsudham@gmail.com>"
+    "Sudham Jayanthi <workwithsudham@gmail.com>",
+    "Ben Khoo <khoobks@gmail.com>"
   ],
   "license": "MIT",
   "engines": {

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -2,7 +2,7 @@ import merge from 'lodash/merge';
 import TypeDefs from './common/typedefs'; // eslint-disable-line no-unused-vars
 import ImageWrapper from './common/image_wrapper';
 import BarcodeDecoder from './decoder/barcode_decoder';
-import BarcodeReader from './reader/barcode_reader';
+import * as Readers from './reader/index';
 import Events from './common/events';
 import CameraAccess from './input/camera_access';
 import ImageDebug from './common/image_debug';
@@ -140,7 +140,7 @@ const QuaggaJSStaticInterface = {
     get default() {
         return QuaggaJSStaticInterface;
     },
-    BarcodeReader,
+    Readers,
     CameraAccess,
     ImageDebug,
     ImageWrapper,
@@ -151,7 +151,7 @@ export default QuaggaJSStaticInterface;
 // export BarcodeReader and other utilities for external plugins
 export {
     BarcodeDecoder,
-    BarcodeReader,
+    Readers,
     CameraAccess,
     ImageDebug,
     ImageWrapper,

--- a/src/reader/2of5_reader.ts
+++ b/src/reader/2of5_reader.ts
@@ -27,7 +27,7 @@ class TwoOfFiveReader extends BarcodeReader {
 
     AVG_CODE_ERROR = 0.30;
 
-    _findPattern(pattern: ReadonlyArray<number>, offset: number, isWhite = false, tryHarder = false): BarcodeInfo | null {
+    protected _findPattern(pattern: ReadonlyArray<number>, offset: number, isWhite = false, tryHarder = false): BarcodeInfo | null {
         const counter = [];
         let counterPos = 0;
         const bestMatch = {
@@ -84,7 +84,7 @@ class TwoOfFiveReader extends BarcodeReader {
         return null;
     }
 
-    _findStart() {
+    protected _findStart(): BarcodePosition | null {
         let startInfo = null;
         let offset = this._nextSet(this._row);
         let narrowBarWidth = 1;
@@ -108,7 +108,7 @@ class TwoOfFiveReader extends BarcodeReader {
         return startInfo;
     }
 
-    _verifyTrailingWhitespace(endInfo: BarcodeInfo) {
+    protected _verifyTrailingWhitespace(endInfo: BarcodeInfo): BarcodePosition | null {
         const trailingWhitespaceEnd = endInfo.end + ((endInfo.end - endInfo.start) / 2);
         if (trailingWhitespaceEnd < this._row.length) {
             if (this._matchRange(endInfo.end, trailingWhitespaceEnd, 0)) {
@@ -118,7 +118,7 @@ class TwoOfFiveReader extends BarcodeReader {
         return null;
     }
 
-    _findEnd() {
+    protected _findEnd(): BarcodePosition | null {
         // TODO: reverse, followed by some calcs, followed by another reverse? really?
         this._row.reverse();
         const offset = this._nextSet(this._row);
@@ -137,11 +137,11 @@ class TwoOfFiveReader extends BarcodeReader {
         return endInfo !== null ? this._verifyTrailingWhitespace(endInfo) : null;
     }
 
-    _verifyCounterLength(counters: Array<number>) {
+    protected _verifyCounterLength(counters: Array<number>) {
         return (counters.length % 10 === 0);
     }
 
-    _decodeCode(counter: ReadonlyArray<number>) {
+    protected _decodeCode(counter: ReadonlyArray<number>): BarcodeInfo | null {
         const epsilon = this.AVG_CODE_ERROR;
         const bestMatch = {
             error: Number.MAX_VALUE,
@@ -152,18 +152,18 @@ class TwoOfFiveReader extends BarcodeReader {
 
         for (let code = 0; code < CODE_PATTERN.length; code++) {
             const error = this._matchPattern(counter, CODE_PATTERN[code]);
-            if (error < bestMatch.error) {
+            if (error < bestMatch.error!) {
                 bestMatch.code = code;
                 bestMatch.error = error;
             }
         }
-        if (bestMatch.error < epsilon) {
+        if (bestMatch.error! < epsilon) {
             return bestMatch;
         }
         return null;
     }
 
-    _decodePayload(counters: ReadonlyArray<number>, result: Array<string>, decodedCodes: Array<BarcodeInfo>) {
+    protected _decodePayload(counters: ReadonlyArray<number>, result: Array<string>, decodedCodes: Array<BarcodeInfo | BarcodePosition>): BarcodeInfo | null {
         let pos = 0;
         const counterLength = counters.length;
         const counter = [0, 0, 0, 0, 0];
@@ -185,7 +185,7 @@ class TwoOfFiveReader extends BarcodeReader {
     }
 
 
-    _decode(row?: Array<number>, start?: BarcodePosition): Barcode | null {
+    public decode(row?: Array<number>, start?: BarcodePosition): Barcode | null {
         const startInfo = this._findStart();
         if (!startInfo) {
             return null;

--- a/src/reader/barcode_reader.ts
+++ b/src/reader/barcode_reader.ts
@@ -55,7 +55,7 @@ export abstract class BarcodeReader {
     // TODO: should add ALPHABETH_STRING, ALPHABET, CHARACTER_ENCODINGS to base class, if they
     // are useful in most readers.
 
-    abstract _decode(row?: Array<number>, start?: BarcodePosition | number): Barcode | null;
+    public abstract decode(row?: Array<number>, start?: BarcodePosition | number): Barcode | null;
 
     static get Exception() {
         return {
@@ -75,14 +75,14 @@ export abstract class BarcodeReader {
         return this;
     }
 
-    _nextUnset(line: ReadonlyArray<number>, start: number = 0): number {
+    protected _nextUnset(line: ReadonlyArray<number>, start: number = 0): number {
         for (let i = start; i < line.length; i++) {
             if (!line[i]) return i;
         }
         return line.length;
     }
 
-    _matchPattern(counter: ReadonlyArray<number>, code: ReadonlyArray<number>, maxSingleError?: number): number {
+    protected _matchPattern(counter: ReadonlyArray<number>, code: ReadonlyArray<number>, maxSingleError?: number): number {
         let error = 0;
         let singleError = 0;
         let sum = 0;
@@ -115,14 +115,14 @@ export abstract class BarcodeReader {
         return error / modulo;
     }
 
-    _nextSet(line: ReadonlyArray<number>, offset: number = 0) {
+    protected _nextSet(line: ReadonlyArray<number>, offset: number = 0) {
         for (let i = offset; i < line.length; i++) {
             if (line[i]) return i;
         }
         return line.length;
     }
 
-    _correctBars(counter: Array<number>, correction: number, indices: Array<number>) {
+    protected _correctBars(counter: Array<number>, correction: number, indices: Array<number>) {
         let length = indices.length;
         let tmp = 0;
         while (length--) {
@@ -133,15 +133,15 @@ export abstract class BarcodeReader {
         }
     }
 
-    decodePattern(pattern: Array<number>) {
+    public decodePattern(pattern: Array<number>) {
         // console.warn('* decodePattern', pattern);
         this._row = pattern;
         // console.warn('* decodePattern calling decode', typeof this, this.constructor, this.FORMAT, JSON.stringify(this));
-        let result = this._decode();
+        let result = this.decode();
         // console.warn('* first result=', result);
         if (result === null) {
             this._row.reverse();
-            result = this._decode();
+            result = this.decode();
             // console.warn('* reversed result=', result);
             if (result) {
                 result.direction = BarcodeDirection.Reverse;
@@ -158,7 +158,7 @@ export abstract class BarcodeReader {
         return result;
     }
 
-    _matchRange(start: number, end: number, value: number) {
+    protected _matchRange(start: number, end: number, value: number) {
         var i;
         start = start < 0 ? 0 : start;
         for (i = start; i < end; i++) {
@@ -169,7 +169,7 @@ export abstract class BarcodeReader {
         return true;
     }
 
-    _fillCounters(offset: number = this._nextUnset(this._row), end: number = this._row.length, isWhite: boolean = true) {
+    protected _fillCounters(offset: number = this._nextUnset(this._row), end: number = this._row.length, isWhite: boolean = true) {
         const counters: Array<number> = [];
         let counterPos = 0;
         counters[counterPos] = 0;
@@ -185,7 +185,7 @@ export abstract class BarcodeReader {
         return counters;
     }
 
-    _toCounters(start: number, counters: Uint16Array | Array<number>) {
+    protected _toCounters(start: number, counters: Uint16Array | Array<number>) {
         const numCounters = counters.length;
         const end = this._row.length;
         let isWhite = !this._row[start];

--- a/src/reader/codabar_reader.ts
+++ b/src/reader/codabar_reader.ts
@@ -32,7 +32,7 @@ class NewCodabarReader extends BarcodeReader {
     _counters: Array<number> = [];
     FORMAT = 'codabar';
 
-    _computeAlternatingThreshold(offset: number, end: number) {
+    protected _computeAlternatingThreshold(offset: number, end: number) {
         let min = Number.MAX_VALUE;
         let max = 0;
         let counter = 0;
@@ -50,7 +50,7 @@ class NewCodabarReader extends BarcodeReader {
         return ((min + max) / 2.0) | 0;
     };
 
-    _toPattern(offset: number) {
+    protected _toPattern(offset: number) {
         const numCounters = 7;
         const end = offset + numCounters;
 
@@ -76,7 +76,7 @@ class NewCodabarReader extends BarcodeReader {
         return pattern;
     };
 
-    _isStartEnd(pattern: number) {
+    protected _isStartEnd(pattern: number) {
         for (let i = 0; i < START_END.length; i++) {
             if (START_END[i] === pattern) {
                 return true;
@@ -85,7 +85,7 @@ class NewCodabarReader extends BarcodeReader {
         return false;
     };
 
-    _sumCounters(start: number, end: number) {
+    protected _sumCounters(start: number, end: number) {
         let sum = 0;
 
         for (let i = start; i < end; i++) {
@@ -94,7 +94,7 @@ class NewCodabarReader extends BarcodeReader {
         return sum;
     };
 
-    _findStart(): BarcodePosition | null {
+    protected _findStart(): BarcodePosition | null {
         let start = this._nextUnset(this._row);
         let end = start;
 
@@ -115,7 +115,7 @@ class NewCodabarReader extends BarcodeReader {
         return null;
     }
 
-    _patternToChar(pattern: number) {
+    protected _patternToChar(pattern: number) {
         for (let i = 0; i < CHARACTER_ENCODINGS.length; i++) {
             if (CHARACTER_ENCODINGS[i] === pattern) {
                 return String.fromCharCode(ALPHABET[i]);
@@ -124,7 +124,7 @@ class NewCodabarReader extends BarcodeReader {
         return null;
     };
 
-    _calculatePatternLength(offset: number) {
+    protected _calculatePatternLength(offset: number) {
         let sum = 0;
 
         for (let i = offset; i < offset + 7; i++) {
@@ -134,7 +134,7 @@ class NewCodabarReader extends BarcodeReader {
         return sum;
     };
 
-    _verifyWhitespace(startCounter: number, endCounter: number) {
+    protected _verifyWhitespace(startCounter: number, endCounter: number) {
         if ((startCounter - 1 <= 0)
             || this._counters[startCounter - 1] >= (this._calculatePatternLength(startCounter) / 2.0)) {
             if ((endCounter + 8 >= this._counters.length)
@@ -145,7 +145,7 @@ class NewCodabarReader extends BarcodeReader {
         return false;
     };
 
-    _charToPattern(char: string) {
+    protected _charToPattern(char: string) {
         const charCode = char.charCodeAt(0);
 
         for (let i = 0; i < ALPHABET.length; i++) {
@@ -156,7 +156,7 @@ class NewCodabarReader extends BarcodeReader {
         return 0x0;
     };
 
-    _thresholdResultPattern(result: ReadonlyArray<string>, startCounter: number) {
+    protected _thresholdResultPattern(result: ReadonlyArray<string>, startCounter: number) {
         const categorization: Threshold = {
                 space: {
                     narrow: { size: 0, counts: 0, min: 0, max: Number.MAX_VALUE },
@@ -193,7 +193,7 @@ class NewCodabarReader extends BarcodeReader {
         return categorization;
     };
 
-    _validateResult(result: ReadonlyArray<string>, startCounter: number) {
+    protected _validateResult(result: ReadonlyArray<string>, startCounter: number) {
         const thresholds = this._thresholdResultPattern(result, startCounter);
         let pos = startCounter;
         let pattern: number;
@@ -214,7 +214,7 @@ class NewCodabarReader extends BarcodeReader {
         return true;
     };
 
-    _decode(row?: Array<number>, start?: BarcodePosition | number | null): Barcode | null {
+    public decode(row?: Array<number>, start?: BarcodePosition | number | null): Barcode | null {
 
         this._counters = this._fillCounters();
         start = this._findStart();

--- a/src/reader/code_128_reader.ts
+++ b/src/reader/code_128_reader.ts
@@ -123,7 +123,7 @@ class Code128Reader extends BarcodeReader {
     FORMAT = 'code_128';
     MODULE_INDICES = { bar: [0, 2, 4], space: [1, 3, 5] };
 
-    _decodeCode(start: number, correction?: BarcodeCorrection) {
+    protected _decodeCode(start: number, correction?: BarcodeCorrection): BarcodeInfo | null {
         const bestMatch = {
             error: Number.MAX_VALUE,
             code: -1,
@@ -177,13 +177,13 @@ class Code128Reader extends BarcodeReader {
         return null;
     };
 
-    _correct(counter: Array<number>, correction: BarcodeCorrection) {
+    protected _correct(counter: Array<number>, correction: BarcodeCorrection) {
         this._correctBars(counter, correction.bar, this.MODULE_INDICES.bar);
         this._correctBars(counter, correction.space, this.MODULE_INDICES.space);
     };
 
     // TODO: _findStart and decodeCode share similar code, can we re-use some?
-    _findStart() {
+    protected _findStart(): BarcodeInfo | null {
         const counter = [0, 0, 0, 0, 0, 0];
         const offset = this._nextSet(this._row);
         const bestMatch = {
@@ -240,7 +240,7 @@ class Code128Reader extends BarcodeReader {
         return null;
     };
 
-    _decode(row?: Array<number>, start?: BarcodePosition): Barcode | null {
+    public decode(row?: Array<number>, start?: BarcodePosition): Barcode | null {
         const startInfo = this._findStart();
         if (startInfo === null) {
             return null;
@@ -262,8 +262,8 @@ class Code128Reader extends BarcodeReader {
             start: startInfo.start,
             end: startInfo.end,
             correction: {
-                bar: startInfo.correction.bar,
-                space: startInfo.correction.space,
+                bar: startInfo.correction!.bar,
+                space: startInfo.correction!.space,
             },
         };
         const decodedCodes = [];
@@ -421,7 +421,7 @@ class Code128Reader extends BarcodeReader {
         };
     };
 
-    _verifyTrailingWhitespace(endInfo: BarcodeInfo): BarcodeInfo | null {
+    protected _verifyTrailingWhitespace(endInfo: BarcodeInfo): BarcodeInfo | null {
 
         var self = this,
             trailingWhitespaceEnd;
@@ -436,7 +436,7 @@ class Code128Reader extends BarcodeReader {
     };
 
 
-    calculateCorrection(expected: ReadonlyArray<number>, normalized: ReadonlyArray<number>, indices: ReadonlyArray<number>): number {
+    public calculateCorrection(expected: ReadonlyArray<number>, normalized: ReadonlyArray<number>, indices: ReadonlyArray<number>): number {
         var length = indices.length,
             sumNormalized = 0,
             sumExpected = 0;

--- a/src/reader/code_32_reader.ts
+++ b/src/reader/code_32_reader.ts
@@ -11,7 +11,7 @@ const code32set = '0123456789BCDFGHJKLMNPQRSTUVWXYZ';
 class Code32Reader extends Code39Reader {
     FORMAT = 'code_32_reader';
 
-    _decodeCode32(code: string) {
+    protected _decodeCode32(code: string) {
         if (/[^0-9BCDFGHJKLMNPQRSTUVWXYZ]/.test(code)) {
             return null;
         }
@@ -27,12 +27,12 @@ class Code32Reader extends Code39Reader {
     }
 
     // TODO (this was todo in original repo, no text was there. sorry.)
-    _checkChecksum(code: string) {
+    protected _checkChecksum(code: string): boolean {
         return !!code;
     }
 
-    _decode(row?: Array<number>, start?: BarcodePosition): Barcode | null {
-        const result = super._decode(row, start);
+    public decode(row?: Array<number>, start?: BarcodePosition): Barcode | null {
+        const result = super.decode(row, start);
         if (!result) {
             return null;
         }

--- a/src/reader/code_39_reader.ts
+++ b/src/reader/code_39_reader.ts
@@ -13,7 +13,7 @@ const ASTERISK = 0x094;
 class Code39Reader extends BarcodeReader {
     FORMAT = 'code_39';
 
-    _findStart() {
+    protected _findStart(): BarcodePosition | null {
         const offset = this._nextSet(this._row);
         let patternStart = offset;
         const counter = new Uint16Array([0, 0, 0, 0, 0, 0, 0, 0, 0]);
@@ -53,7 +53,7 @@ class Code39Reader extends BarcodeReader {
         return null;
     };
 
-    _toPattern(counters: Uint16Array) {
+    protected _toPattern(counters: Uint16Array): number {
         const numCounters = counters.length;
         let maxNarrowWidth = 0;
         let numWideBars = numCounters;
@@ -86,7 +86,7 @@ class Code39Reader extends BarcodeReader {
         return -1;
     };
 
-    _findNextWidth(counters: Uint16Array, current: number) {
+    protected _findNextWidth(counters: Uint16Array, current: number): number {
         let minWidth = Number.MAX_VALUE;
 
         for (let i = 0; i < counters.length; i++) {
@@ -98,7 +98,7 @@ class Code39Reader extends BarcodeReader {
         return minWidth;
     };
 
-    _patternToChar(pattern: number) {
+    protected _patternToChar(pattern: number): string | null {
         for (let i = 0; i < CHARACTER_ENCODINGS.length; i++) {
             if (CHARACTER_ENCODINGS[i] === pattern) {
                 return String.fromCharCode(ALPHABET[i]);
@@ -107,7 +107,7 @@ class Code39Reader extends BarcodeReader {
         return null;
     };
 
-    _verifyTrailingWhitespace(lastStart: number, nextStart: number, counters: Uint16Array) {
+    protected _verifyTrailingWhitespace(lastStart: number, nextStart: number, counters: Uint16Array): boolean {
         const patternSize = ArrayHelper.sum(counters);
 
         const trailingWhitespaceEnd = nextStart - lastStart - patternSize;
@@ -117,7 +117,7 @@ class Code39Reader extends BarcodeReader {
         return false;
     };
 
-    _decode(row?: Array<number>, start?: BarcodePosition | number | null): Barcode | null {
+    public decode(row?: Array<number>, start?: BarcodePosition | number | null): Barcode | null {
         let counters = new Uint16Array([0, 0, 0, 0, 0, 0, 0, 0, 0]);
         const result: Array<string> = [];
         start = this._findStart();

--- a/src/reader/code_39_vin_reader.ts
+++ b/src/reader/code_39_vin_reader.ts
@@ -10,14 +10,14 @@ class Code39VINReader extends Code39Reader {
     FORMAT = 'code_39_vin';
 
     // TODO (this was todo in original repo, no text was there. sorry.)
-    _checkChecksum(code: string) {
+    protected _checkChecksum(code: string): boolean {
         return !!code;
     }
 
     // Cribbed from:
     // https://github.com/zxing/zxing/blob/master/core/src/main/java/com/google/zxing/client/result/VINResultParser.java
-    _decode(row?: Array<number>, start?: BarcodePosition): Barcode | null {
-        const result = super._decode(row, start);
+    public decode(row?: Array<number>, start?: BarcodePosition): Barcode | null {
+        const result = super.decode(row, start);
         if (!result) {
             return null;
         }

--- a/src/reader/code_93_reader.ts
+++ b/src/reader/code_93_reader.ts
@@ -14,7 +14,7 @@ const ASTERISK = 0x15E;
 
 class Code93Reader extends BarcodeReader {
     FORMAT = 'code_93';
-    _patternToChar(pattern: number) {
+    protected _patternToChar(pattern: number): string | null {
         for (let i = 0; i < CHARACTER_ENCODINGS.length; i++) {
             if (CHARACTER_ENCODINGS[i] === pattern) {
                 return String.fromCharCode(ALPHABET[i]);
@@ -23,7 +23,7 @@ class Code93Reader extends BarcodeReader {
         return null;
     };
 
-    _toPattern(counters: Uint16Array) {
+    protected _toPattern(counters: Uint16Array): number {
         const numCounters = counters.length;
         const sum = counters.reduce((prev, next) => prev + next, 0);
         let pattern = 0;
@@ -44,7 +44,7 @@ class Code93Reader extends BarcodeReader {
         return pattern;
     };
 
-    _findStart() {
+    protected _findStart(): BarcodePosition | null {
         const offset = this._nextSet(this._row);
         let patternStart = offset;
         const counter = new Uint16Array([0, 0, 0, 0, 0, 0]);
@@ -84,14 +84,14 @@ class Code93Reader extends BarcodeReader {
         return null;
     };
 
-    _verifyEnd(lastStart: number, nextStart: number) {
+    protected _verifyEnd(lastStart: number, nextStart: number): boolean {
         if (lastStart === nextStart || !this._row[nextStart]) {
             return false;
         }
         return true;
     };
 
-    _decodeExtended(charArray: Array<string>) {
+    protected _decodeExtended(charArray: Array<string>): string[] | null {
         const length = charArray.length;
         const result: Array<string> = [];
         for (let i = 0; i < length; i++) {
@@ -154,7 +154,7 @@ class Code93Reader extends BarcodeReader {
         return result;
     };
 
-    _matchCheckChar(charArray: Array<string>, index: number, maxWeight: number) {
+    protected _matchCheckChar(charArray: Array<string>, index: number, maxWeight: number): boolean {
         const arrayToCheck = charArray.slice(0, index);
         const length = arrayToCheck.length;
         const weightedSums = arrayToCheck.reduce((sum, char, i) => {
@@ -167,12 +167,12 @@ class Code93Reader extends BarcodeReader {
         return checkChar === charArray[index].charCodeAt(0);
     };
 
-    _verifyChecksums(charArray: Array<string>) {
+    protected _verifyChecksums(charArray: Array<string>): boolean {
         return this._matchCheckChar(charArray, charArray.length - 2, 20)
             && this._matchCheckChar(charArray, charArray.length - 1, 15);
     };
 
-    _decode(row?: Array<number>, start?: BarcodePosition | number | null): Barcode | null {
+    public decode(row?: Array<number>, start?: BarcodePosition | number | null): Barcode | null {
         start = this._findStart();
         if (!start) {
             return null;

--- a/src/reader/ean_2_reader.ts
+++ b/src/reader/ean_2_reader.ts
@@ -4,7 +4,7 @@ import { BarcodePosition, Barcode, BarcodeInfo } from './barcode_reader';
 
 class EAN2Reader extends EANReader {
     FORMAT = 'ean_2';
-    _decode(row?: Array<number>, start?: number): Barcode | null {
+    public decode(row?: Array<number>, start?: number): Barcode | null {
         if (row) {
             this._row = row;
         }

--- a/src/reader/ean_5_reader.ts
+++ b/src/reader/ean_5_reader.ts
@@ -29,7 +29,7 @@ function extensionChecksum(result: Array<number>) {
 
 class EAN5Reader extends EANReader {
     FORMAT = 'ean_5';
-    _decode(row?: Array<number>, start?: number): Barcode | null {
+    public decode(row?: Array<number>, start?: number): Barcode | null {
         if (start === undefined) {
             return null;
         }

--- a/src/reader/ean_reader.ts
+++ b/src/reader/ean_reader.ts
@@ -42,7 +42,8 @@ class EANReader extends BarcodeReader {
     constructor(config?: BarcodeReaderConfig, supplements?: Array<BarcodeReader>) {
         super(merge({ supplements: [] }, config), supplements);
     }
-    _findPattern(pattern: ReadonlyArray<number>, offset: number, isWhite: boolean, tryHarder: boolean): BarcodePosition | null {
+
+    protected _findPattern(pattern: ReadonlyArray<number>, offset: number, isWhite: boolean, tryHarder: boolean): BarcodePosition | null {
         const counter = new Array<number>(pattern.length).fill(0);
         const bestMatch: BarcodePosition = {
             error: Number.MAX_VALUE,
@@ -96,7 +97,7 @@ class EANReader extends BarcodeReader {
     }
 
     // TODO: findPattern and decodeCode appear to share quite similar code, can it be reduced?
-    _decodeCode(start: number, coderange?: number): BarcodeInfo | null {
+    protected _decodeCode(start: number, coderange?: number): BarcodeInfo | null {
         // console.warn('* decodeCode', start, coderange);
         const counter = [0, 0, 0, 0];
         const offset = start;
@@ -298,7 +299,7 @@ class EANReader extends BarcodeReader {
         for (let i = 0; i < this.supplements.length; i++) {
             // console.warn('* extensions loop', i, this.supplements[i], this.supplements[i]._decode);
             try {
-                let result = this.supplements[i]._decode(this._row, startInfo.end);
+                let result = this.supplements[i].decode(this._row, startInfo.end);
                 // console.warn('* decode result=', result);
                 if (result !== null) {
                     return {
@@ -319,7 +320,7 @@ class EANReader extends BarcodeReader {
         return null;
     }
 
-    _decode(row?: Array<number>, start?: BarcodePosition | number): Barcode | null {
+    public decode(row?: Array<number>, start?: BarcodePosition | number): Barcode | null {
         // console.warn('* decode', row);
         // console.warn('* decode', start);
         const result = new Array<number>();

--- a/src/reader/index.ts
+++ b/src/reader/index.ts
@@ -1,0 +1,33 @@
+import BarcodeReader from './barcode_reader';
+import TwoOfFiveReader from './2of5_reader';
+import NewCodabarReader from './codabar_reader';
+import Code128Reader from './code_128_reader';
+import Code32Reader from './code_32_reader';
+import Code39Reader from './code_39_reader';
+import Code39VINReader from './code_39_vin_reader';
+import Code93Reader from './code_93_reader';
+import EAN2Reader from './ean_2_reader';
+import EAN5Reader from './ean_5_reader';
+import EAN8Reader from './ean_8_reader';
+import EANReader from './ean_reader';
+import I2of5Reader from './i2of5_reader';
+import UPCEReader from './upc_e_reader';
+import UPCReader from './upc_reader';
+
+export {
+    BarcodeReader,
+    TwoOfFiveReader,
+    NewCodabarReader,
+    Code128Reader,
+    Code32Reader,
+    Code39Reader,
+    Code39VINReader,
+    Code93Reader,
+    EAN2Reader,
+    EAN5Reader,
+    EAN8Reader,
+    EANReader,
+    I2of5Reader,
+    UPCEReader,
+    UPCReader,    
+}

--- a/src/reader/upc_e_reader.ts
+++ b/src/reader/upc_e_reader.ts
@@ -29,7 +29,7 @@ class UPCEReader extends EANReader {
         return outCode as BarcodeInfo;
     };
 
-    _determineParity(codeFrequency: number, result: Array<number>) {
+    protected _determineParity(codeFrequency: number, result: Array<number>) {
         for (let nrSystem = 0; nrSystem < this.CODE_FREQUENCY.length; nrSystem++){
             for (let i = 0; i < this.CODE_FREQUENCY[nrSystem].length; i++) {
                 if (codeFrequency === this.CODE_FREQUENCY[nrSystem][i]) {
@@ -42,7 +42,7 @@ class UPCEReader extends EANReader {
         return false;
     };
 
-    _convertToUPCA(result: Array<number>) {
+    protected _convertToUPCA(result: Array<number>) {
         let upca = [result[0]];
         const lastDigit = result[result.length - 2];
 

--- a/src/reader/upc_reader.ts
+++ b/src/reader/upc_reader.ts
@@ -3,8 +3,8 @@ import { BarcodePosition, Barcode } from './barcode_reader';
 
 class UPCReader extends EANReader {
     FORMAT = 'upc_a';
-    _decode(row?: Array<number>, start?: BarcodePosition | number): Barcode | null {
-        const result = EANReader.prototype._decode.call(this);
+    decode(row?: Array<number>, start?: BarcodePosition | number): Barcode | null {
+        const result = EANReader.prototype.decode.call(this);
 
         if (result && result.code && result.code.length === 13 && result.code.charAt(0) === '0') {
             result.code = result.code.substring(1);


### PR DESCRIPTION
Hi,

The main reason behind this pull request is that I would like to extend one of the barcode readers to create a custom barcode reader of my own. The problem I had is that `quagga.d.ts` doesn't export the reader class that I need to extend. 

This pull request adds all of the reader classes to `quagga.d.ts`. In doing so I have also made these other changes

- Added the `protected` access modifier to most functions in the reader classes that have an underscore prefix. This seemed to be the original intent however without the access modifier they would all be public. Since these classes were not exported previously there should be no usages outside of this project so the change seems safe to me.
- Added typescript return type to functions where they were missing.
- Renamed `BarcodeReader._decode` to `BarcodeReader.decode`. This is because the `EANReader` attempts to call that function for each of the supplementary readers so the `decode` function cannot be protected.