### PR TITLE
remove testing for node 10 as node 10 is no longer officially supported by node

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
not causing a version jump as this is just removing auto test, we are making
no functional changes nor any code changes at this time.