### PR TITLE
fix: publish config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '14.x'
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        registry-url: 'https://registry.npmjs.org'
     - name: npm install, build, test, publish
       run: |
         node --version


### PR DESCRIPTION
I think you need to specify the registry-url in actions/setup-node to publish to npm from GitHub Actions.

See https://github.com/RollingVersions/RollingVersions/issues/215 for more context.