### PR TITLE
Update config type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "Tony Brix <tony@brix.ninja>",
     "Alex Howes <alex@alexhowes.co.uk>",
     "Sudham Jayanthi <workwithsudham@gmail.com>",
-    "Ben Khoo <khoobks@gmail.com>"
+    "Ben Khoo <khoobks@gmail.com>",
+    "Andy Edinborough <andy@edinborough.org>
   ],
   "license": "MIT",
   "engines": {

--- a/type-definitions/quagga.d.ts
+++ b/type-definitions/quagga.d.ts
@@ -753,7 +753,7 @@ export interface QuaggaJSConfigObject {
      * Ex: '/test/fixtures/code_128/image-001.jpg'
      * or: 'data:image/jpg;base64,' + data
      */
-    src?: string;
+    src?: string | Uint8Array | Buffer;
 
     inputStream?: {
         /**
@@ -800,6 +800,8 @@ export interface QuaggaJSConfigObject {
              */
             bottom?: string;
         };
+        
+        mimeType?: string;
 
         singleChannel?: boolean;
         size?: number;

--- a/type-definitions/quagga.d.ts
+++ b/type-definitions/quagga.d.ts
@@ -801,7 +801,7 @@ export interface QuaggaJSConfigObject {
             bottom?: string;
         };
         
-        mimeType?: string;
+        mime?: string;
 
         singleChannel?: boolean;
         size?: number;


### PR DESCRIPTION
`mimeType` is used to properly decode `src`, which can be a Buffer or Uint8Array