### PR TITLE
fix: import for integration tests

### DIFF
--- a/test/integration/integration.spec.ts
+++ b/test/integration/integration.spec.ts
@@ -4,7 +4,7 @@
 // TODO: write a test that allows for locate: false and locator configs to be tested.
 
 // import Quagga from '../../src/quagga';
-import Quagga from '../../';
+import Quagga from '../../src/quagga';
 import { QuaggaJSConfigObject } from '../../type-definitions/quagga';
 import { expect } from 'chai';
 import ExternalCode128Reader from '../../src/reader/code_128_reader';


### PR DESCRIPTION
The integration tests were failing with the following message:

```
Error: Webpack Compilation Error
Module not found: Error: Can't resolve '../../' in '/Users/x/Repositories/quagga2/test/integration'
```

This change fixes the import so the integration tests can run properly.

I'm not sure if the previous version is required for the CI since there is a commented import.