### PR TITLE
Fix: Add typeof checks before all ENV usages to prevent ReferenceError

### DIFF
--- a/src/decoder/barcode_decoder.js
+++ b/src/decoder/barcode_decoder.js
@@ -58,7 +58,7 @@ export default {
         initConfig();
 
         function initCanvas() {
-            if (ENV.development && typeof document !== 'undefined') {
+            if (typeof ENV !== 'undefined' && ENV.development && typeof document !== 'undefined') {
                 const $debug = document.querySelector('#debug.detection');
                 _canvas.dom.frequency = document.querySelector('canvas.frequency');
                 if (!_canvas.dom.frequency) {
@@ -68,7 +68,7 @@ export default {
                         $debug.appendChild(_canvas.dom.frequency);
                     }
                 }
-                if (ENV.development && config.debug?.printReaderInfo) {
+                if (typeof ENV !== 'undefined' && ENV.development && config.debug?.printReaderInfo) {
                     console.warn('* barcode decoder initCanvas getcontext 2d');
                 }
                 _canvas.ctx.frequency = _canvas.dom.frequency.getContext('2d');
@@ -102,7 +102,7 @@ export default {
                 } else if (typeof readerConfig === 'string') {
                     reader = readerConfig;
                 }
-                if (ENV.development && config.debug?.printReaderInfo) {
+                if (typeof ENV !== 'undefined' && ENV.development && config.debug?.printReaderInfo) {
                     console.log('Before registering reader: ', reader);
                 }
                 if (configuration.supplements) {
@@ -117,7 +117,7 @@ export default {
                     throw err;
                 }
             });
-            if (ENV.development && config.debug?.printReaderInfo) {
+            if (typeof ENV !== 'undefined' && ENV.development && config.debug?.printReaderInfo) {
                 console.log(`Registered Readers: ${_barcodeReaders
                     .map((reader) => JSON.stringify({ format: reader.FORMAT, config: reader.config }))
                     .join(', ')}`);
@@ -125,7 +125,7 @@ export default {
         }
 
         function initConfig() {
-            if (ENV.development && typeof document !== 'undefined') {
+            if (typeof ENV !== 'undefined' && ENV.development && typeof document !== 'undefined') {
                 let i;
                 const vis = [{
                     node: _canvas.dom.frequency,
@@ -190,14 +190,14 @@ export default {
             let i;
             const barcodeLine = Bresenham.getBarcodeLine(inputImageWrapper, line[0], line[1]);
 
-            if (ENV.development && config.debug.showFrequency) {
+            if (typeof ENV !== 'undefined' && ENV.development && config.debug.showFrequency) {
                 ImageDebug.drawPath(line, { x: 'x', y: 'y' }, _canvas.ctx.overlay, { color: 'red', lineWidth: 3 });
                 Bresenham.debug.printFrequency(barcodeLine.line, _canvas.dom.frequency);
             }
 
             Bresenham.toBinaryLine(barcodeLine);
 
-            if (ENV.development && config.debug.showPattern) {
+            if (typeof ENV !== 'undefined' && ENV.development && config.debug.showPattern) {
                 Bresenham.debug.printPattern(barcodeLine.line, _canvas.dom.pattern);
             }
 
@@ -280,7 +280,7 @@ export default {
             const ctx = _canvas.ctx.overlay;
             let result;
 
-            if (ENV.development) {
+            if (typeof ENV !== 'undefined' && ENV.development) {
                 if (config.debug.drawBoundingBox && ctx) {
                     ImageDebug.drawPath(box, { x: 0, y: 1 }, ctx, { color: 'blue', lineWidth: 2 });
                 }
@@ -303,7 +303,7 @@ export default {
                 return null;
             }
 
-            if (ENV.development && result && config.debug.drawScanline && ctx) {
+            if (typeof ENV !== 'undefined' && ENV.development && result && config.debug.drawScanline && ctx) {
                 ImageDebug.drawPath(line, { x: 'x', y: 'y' }, ctx, { color: 'red', lineWidth: 3 });
             }
 

--- a/src/input/camera_access.ts
+++ b/src/input/camera_access.ts
@@ -18,7 +18,7 @@ function waitForVideo(video: HTMLVideoElement): Promise<void> {
         function checkVideo(): void {
             if (attempts > 0) {
                 if (video.videoWidth > 10 && video.videoHeight > 10) {
-                    if (ENV.development) {
+                    if (typeof ENV !== 'undefined' && ENV.development) {
                         console.log(`* dev: checkVideo found ${video.videoWidth}px x ${video.videoHeight}px`);
                     }
                     resolve();

--- a/src/input/frame_grabber.js
+++ b/src/input/frame_grabber.js
@@ -27,7 +27,7 @@ FrameGrabber.create = function (inputStream, canvas) {
     const _stepSizeY = _videoSize.y / _canvasSize.y;
     const _streamConfig = inputStream.getConfig();
 
-    if (ENV.development && _streamConfig.debug?.showImageDetails) {
+    if (typeof ENV !== 'undefined' && ENV.development && _streamConfig.debug?.showImageDetails) {
         console.log('FrameGrabber', JSON.stringify({
             videoSize: _grayImageArray.shape,
             canvasSize: _canvasImageArray.shape,

--- a/src/input/frame_grabber_browser.js
+++ b/src/input/frame_grabber_browser.js
@@ -11,13 +11,13 @@ const TO_RADIANS = Math.PI / 180;
 
 function adjustCanvasSize(canvas, targetSize, debug) {
     if (canvas.width !== targetSize.x) {
-        if (ENV.development && debug?.showImageDetails) {
+        if (typeof ENV !== 'undefined' && ENV.development && debug?.showImageDetails) {
             console.log('WARNING: canvas-size needs to be adjusted');
         }
         canvas.width = targetSize.x;
     }
     if (canvas.height !== targetSize.y) {
-        if (ENV.development && debug?.showImageDetails) {
+        if (typeof ENV !== 'undefined' && ENV.development && debug?.showImageDetails) {
             console.log('WARNING: canvas-size needs to be adjusted');
         }
         canvas.height = targetSize.y;
@@ -44,12 +44,12 @@ FrameGrabber.create = function (inputStream, canvas) {
     _canvas = canvas || document.createElement('canvas');
     _canvas.width = _canvasSize.x;
     _canvas.height = _canvasSize.y;
-    if (ENV.development && _streamConfig.debug?.showImageDetails) {
+    if (typeof ENV !== 'undefined' && ENV.development && _streamConfig.debug?.showImageDetails) {
         console.warn('*** frame_grabber_browser: willReadFrequently=', willReadFrequently, 'canvas=', _canvas);
     }
     _ctx = _canvas.getContext('2d', { willReadFrequently: !!willReadFrequently }); // double not because we have an optional bool that needs to pass as a bool
     _data = new Uint8Array(_size.x * _size.y);
-    if (ENV.development && _streamConfig.debug?.showImageDetails) {
+    if (typeof ENV !== 'undefined' && ENV.development && _streamConfig.debug?.showImageDetails) {
         console.log('FrameGrabber', JSON.stringify({
             size: _size,
             topRight,

--- a/src/input/image_loader.js
+++ b/src/input/image_loader.js
@@ -36,7 +36,7 @@ ImageLoader.load = function (directory, callback, offset, size, sequence, config
             }
         }
         if (notloadedImgs.length === 0) {
-            if (ENV.development && config?.debug?.showImageDetails) {
+            if (typeof ENV !== 'undefined' && ENV.development && config?.debug?.showImageDetails) {
                 console.log(`Images loaded: ${htmlImagesArray.length} image${htmlImagesArray.length !== 1 ? 's' : ''} from ${sequence === false ? directory : directory + ' (sequence)'}`);
             }
             if (sequence === false) {

--- a/src/input/input_stream/input_stream.ts
+++ b/src/input/input_stream/input_stream.ts
@@ -106,7 +106,7 @@ const inputStreamFactory: InputStreamFactory = {
                 const pixels = await getPixels(uint8Data, mimeType);
 
                 loaded = true;
-                if (ENV.development) {
+                if (typeof ENV !== 'undefined' && ENV.development) {
                     console.log('* InputStreamNode pixels.shape', pixels.shape);
                 }
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/locator/barcode_locator.js
+++ b/src/locator/barcode_locator.js
@@ -89,11 +89,11 @@ function initCanvas() {
     }
     _canvasContainer.dom.binary = document.createElement('canvas');
     _canvasContainer.dom.binary.className = 'binaryBuffer';
-    if (ENV.development && _config.debug.showCanvas === true) {
+    if (typeof ENV !== 'undefined' && ENV.development && _config.debug.showCanvas === true) {
         document.querySelector('#debug').appendChild(_canvasContainer.dom.binary);
     }
     const willReadFrequently = !!_config.willReadFrequently;
-    if (ENV.development && _config.debug?.showCanvas) {
+    if (typeof ENV !== 'undefined' && ENV.development && _config.debug?.showCanvas) {
         console.warn('* initCanvas willReadFrequently', willReadFrequently, _config);
     }
     _canvasContainer.ctx.binary = _canvasContainer.dom.binary.getContext('2d', { willReadFrequently });
@@ -123,7 +123,7 @@ function boxFromPatches(patches) {
     for (i = 0; i < patches.length; i++) {
         patch = patches[i];
         overAvg += patch.rad;
-        if (ENV.development && _config.debug.showPatches) {
+        if (typeof ENV !== 'undefined' && ENV.development && _config.debug.showPatches) {
             ImageDebug.drawRect(patch.pos, _subImageWrapper.size, _canvasContainer.ctx.binary, { color: 'red' });
         }
     }
@@ -144,7 +144,7 @@ function boxFromPatches(patches) {
             vec2.transformMat2(patch.box[j], patch.box[j], transMat);
         }
 
-        if (ENV.development && _config.debug.boxFromPatches.showTransformed) {
+        if (typeof ENV !== 'undefined' && ENV.development && _config.debug.boxFromPatches.showTransformed) {
             ImageDebug.drawPath(patch.box, { x: 0, y: 1 }, _canvasContainer.ctx.binary, { color: '#99ff00', lineWidth: 2 });
         }
     }
@@ -170,7 +170,7 @@ function boxFromPatches(patches) {
 
     box = [[minx, miny], [maxx, miny], [maxx, maxy], [minx, maxy]];
 
-    if (ENV.development && _config.debug.boxFromPatches.showTransformedBox) {
+    if (typeof ENV !== 'undefined' && ENV.development && _config.debug.boxFromPatches.showTransformedBox) {
         ImageDebug.drawPath(box, { x: 0, y: 1 }, _canvasContainer.ctx.binary, { color: '#ff0000', lineWidth: 2 });
     }
 
@@ -181,7 +181,7 @@ function boxFromPatches(patches) {
         vec2.transformMat2(box[j], box[j], transMat);
     }
 
-    if (ENV.development && _config.debug.boxFromPatches.showBB) {
+    if (typeof ENV !== 'undefined' && ENV.development && _config.debug.boxFromPatches.showBB) {
         ImageDebug.drawPath(box, { x: 0, y: 1 }, _canvasContainer.ctx.binary, { color: '#ff0000', lineWidth: 2 });
     }
 
@@ -198,7 +198,7 @@ function boxFromPatches(patches) {
 function binarizeImage() {
     otsuThreshold(_currentImageWrapper, _binaryImageWrapper);
     _binaryImageWrapper.zeroBorder();
-    if (ENV.development && _config.debug.showCanvas) {
+    if (typeof ENV !== 'undefined' && ENV.development && _config.debug.showCanvas) {
         _binaryImageWrapper.show(_canvasContainer.dom.binary, 255);
     }
 }
@@ -231,7 +231,7 @@ function findPatches() {
             rasterizer = Rasterizer.create(_skelImageWrapper, _labelImageWrapper);
             rasterResult = rasterizer.rasterize(0);
 
-            if (ENV.development && _config.debug.showLabels) {
+            if (typeof ENV !== 'undefined' && ENV.development && _config.debug.showLabels) {
                 _labelImageWrapper.overlay(_canvasContainer.dom.binary, Math.floor(360 / rasterResult.count),
                     { x, y });
             }
@@ -244,7 +244,7 @@ function findPatches() {
         }
     }
 
-    if (ENV.development && _config.debug.showFoundPatches) {
+    if (typeof ENV !== 'undefined' && ENV.development && _config.debug.showFoundPatches) {
         for (i = 0; i < patchesFound.length; i++) {
             patch = patchesFound[i];
             ImageDebug.drawRect(patch.pos, _subImageWrapper.size, _canvasContainer.ctx.binary,
@@ -317,7 +317,7 @@ function findBoxes(topLabels, maxLabel) {
             boxes.push(box);
 
             // draw patch-labels if requested
-            if (ENV.development && _config.debug.showRemainingPatchLabels) {
+            if (typeof ENV !== 'undefined' && ENV.development && _config.debug.showRemainingPatchLabels) {
                 for (j = 0; j < patches.length; j++) {
                     patch = patches[j];
                     hsv[0] = (topLabels[i].label / (maxLabel + 1)) * 360;
@@ -354,7 +354,7 @@ function skeletonize(x, y) {
     _skeletonizer.skeletonize();
 
     // Show skeleton if requested
-    if (ENV.development && _config.debug.showSkeleton) {
+    if (typeof ENV !== 'undefined' && ENV.development && _config.debug.showSkeleton) {
         _skelImageWrapper.overlay(_canvasContainer.dom.binary, 360, imageRef(x, y));
     }
 }
@@ -504,7 +504,7 @@ function rasterizeAngularSimilarity(patchesFound) {
     }
 
     // draw patch-labels if requested
-    if (ENV.development && _config.debug.showPatchLabels) {
+    if (typeof ENV !== 'undefined' && ENV.development && _config.debug.showPatchLabels) {
         for (j = 0; j < _patchLabelGrid.data.length; j++) {
             if (_patchLabelGrid.data[j] > 0 && _patchLabelGrid.data[j] <= label) {
                 patch = _imageToPatchGrid.data[j];
@@ -578,7 +578,7 @@ export default {
         };
 
         patchSize = calculatePatchSize(config.patchSize, size);
-        if (ENV.development && config.debug?.showPatchSize) {
+        if (typeof ENV !== 'undefined' && ENV.development && config.debug?.showPatchSize) {
             console.log(`Patch-Size: ${JSON.stringify(patchSize)}`);
         }
 

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -102,7 +102,7 @@ const QuaggaJSStaticInterface = {
                 size: 800,
                 src: config.src,
             },
-            numOfWorkers: (ENV.development && config.debug) ? 0 : 1,
+            numOfWorkers: (typeof ENV !== 'undefined' && ENV.development && config.debug) ? 0 : 1,
             locator: {
                 halfSample: false,
             },

--- a/src/quagga/initBuffers.ts
+++ b/src/quagga/initBuffers.ts
@@ -15,7 +15,7 @@ export default function initBuffers(
         type: 'XYSize',
     });
 
-    if (ENV.development && (locator as any).config?.debug?.showImageDetails) {
+    if (typeof ENV !== 'undefined' && ENV.development && (locator as any).config?.debug?.showImageDetails) {
         console.log(`image wrapper size ${inputImageWrapper.size}`);
     }
     const boxSize = [

--- a/src/quagga/initCanvas.ts
+++ b/src/quagga/initCanvas.ts
@@ -13,7 +13,7 @@ function findOrCreateCanvas(selector: string, className: string) {
 
 function getCanvasAndContext(selector: string, className: string, options: { willReadFrequently: boolean; debug?: any }) {
     const canvas = findOrCreateCanvas(selector, className);
-    if (ENV.development && options.debug?.showImageDetails) {
+    if (typeof ENV !== 'undefined' && ENV.development && options.debug?.showImageDetails) {
         console.warn('* initCanvas getCanvasAndContext');
     }
     const context = canvas.getContext('2d', { willReadFrequently: options.willReadFrequently });

--- a/src/quagga/qworker.ts
+++ b/src/quagga/qworker.ts
@@ -135,7 +135,7 @@ export function initWorker(config: QuaggaJSConfigObject, inputStream: any, cb: F
             URL.revokeObjectURL(blobURL);
             workerThread.busy = false;
             workerThread.imageData = new Uint8Array(e.data.imageData);
-            if (ENV.development) {
+            if (typeof ENV !== 'undefined' && ENV.development) {
                 console.log('Worker initialized');
             }
             cb(workerThread);
@@ -149,7 +149,7 @@ export function initWorker(config: QuaggaJSConfigObject, inputStream: any, cb: F
                 publishResult(e.data.result, workerThread.imageData);
             }
         } else if (e.data.event === 'error') {
-            if (ENV.development) {
+            if (typeof ENV !== 'undefined' && ENV.development) {
                 console.log('Worker error: ' + e.data.message);
             }
         }
@@ -171,7 +171,7 @@ export function adjustWorkerPool(capacity: number, config?: QuaggaJSConfigObject
         const workersToTerminate = workerPool.slice(increaseBy);
         workersToTerminate.forEach(function (workerThread) {
             workerThread.worker.terminate();
-            if (ENV.development) {
+            if (typeof ENV !== 'undefined' && ENV.development) {
                 console.log('Worker terminated!');
             }
         });

--- a/src/reader/code_39_vin_reader.ts
+++ b/src/reader/code_39_vin_reader.ts
@@ -32,7 +32,7 @@ class Code39VINReader extends Code39Reader {
         code = code.replace(patterns.IOQ, '');
 
         if (!code.match(patterns.AZ09)) {
-            if (ENV.development) {
+            if (typeof ENV !== 'undefined' && ENV.development) {
                 console.log('Failed AZ09 pattern code:', code);
             }
             return null;


### PR DESCRIPTION
ENV is only defined by webpack DefinePlugin during builds, not when running TypeScript tests directly. All ENV usage must check typeof ENV !== 'undefined' first to avoid ReferenceError in test environments.

Fixed ENV checks in:
- src/quagga.js (decodeSingle)
- src/decoder/barcode_decoder.js (multiple locations)
- src/input/input_stream/input_stream.ts
- src/reader/code_39_vin_reader.ts
- src/quagga/initCanvas.ts
- src/quagga/initBuffers.ts
- src/quagga/qworker.ts
- src/input/frame_grabber.js
- src/input/camera_access.ts
- src/input/image_loader.js
- src/input/frame_grabber_browser.js
- src/locator/barcode_locator.js

This allows tests to run in TypeScript environment without ENV being defined.