### PR TITLE
Potential fix for code scanning alert no. 1: Default version of SSL/TLS may be insecure

### DIFF
--- a/simple-https-server.py
+++ b/simple-https-server.py
@@ -26,5 +26,5 @@ print 'host is ', host
 print 'port is ', port
 
 httpd = BaseHTTPServer.HTTPServer((host, port), SimpleHTTPServer.SimpleHTTPRequestHandler)
-httpd.socket = ssl.wrap_socket (httpd.socket, certfile='./server.pem', server_side=True)
+httpd.socket = ssl.wrap_socket(httpd.socket, certfile='./server.pem', server_side=True, ssl_version=ssl.PROTOCOL_TLSv1_2)
 httpd.serve_forever()


### PR DESCRIPTION
Potential fix for [https://github.com/ericblade/quagga2/security/code-scanning/1](https://github.com/ericblade/quagga2/security/code-scanning/1)

To address the issue, the code should explicitly specify a secure protocol version when wrapping the socket with SSL. The best current option is to use `ssl.PROTOCOL_TLSv1_2`, which enforces TLS 1.2, or better yet, switch to a modern approach using an `ssl.SSLContext`. However, for minimal change and as required by the prompt, the fix here is to add the `ssl_version=ssl.PROTOCOL_TLSv1_2` argument to the `ssl.wrap_socket` call on line 29 of `simple-https-server.py`. This ensures only TLS 1.2 is used, greatly improving security without altering any other functionality. The required import for `ssl.PROTOCOL_TLSv1_2` is already present (`import ssl`), so no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
