### PR TITLE
chore: Move gl-matrix from dev-dependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@ericblade/quagga2",
       "version": "1.10.1",
       "license": "MIT",
+      "dependencies": {
+        "gl-matrix": "^3.4.4"
+      },
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -44,7 +47,6 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-typescript-sort-keys": "^3.3.0",
-        "gl-matrix": "^3.4.4",
         "lodash": "^4.17.21",
         "mocha": "^5.2.0",
         "ndarray": "^1.0.19",
@@ -8992,7 +8994,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
       "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/glob": {
@@ -16186,7 +16187,8 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@babel/plugin-syntax-import-assertions": {
       "version": "7.27.1",
@@ -18520,7 +18522,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aggregate-error": {
       "version": "3.0.1",
@@ -18556,13 +18559,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -22149,8 +22154,7 @@
     "gl-matrix": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
-      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
-      "dev": true
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="
     },
     "glob": {
       "version": "7.2.0",
@@ -25493,7 +25497,8 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
       "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "3.0.0",
@@ -25702,7 +25707,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "iconv-lite": {
           "version": "0.6.2",
@@ -26182,7 +26188,8 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "picomatch": {
           "version": "4.0.3",
@@ -26291,13 +26298,15 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
       "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-mocha": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-11.1.0.tgz",
       "integrity": "sha512-yT7FfzNRCu8ZKkYvAOiH01xNma/vLq6Vit7yINKYFNVP8e5UyrYXSOMIipERTpzVKJQ4Qcos5bQo1tNERNZevQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-typescript-sort-keys": "^3.3.0",
-    "gl-matrix": "^3.4.4",
     "lodash": "^4.17.21",
     "mocha": "^5.2.0",
     "ndarray": "^1.0.19",
@@ -190,5 +189,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "gl-matrix": "^3.4.4"
   }
 }


### PR DESCRIPTION
The type definitions rely on vec2 from gl-matrix https://github.com/ericblade/quagga2/blob/19d3c89beec9c598141d98b557eaaee1fd29ed98/type-definitions/quagga.d.ts#L6

Therefore gl-matrix needs to be shipped with quagga2.